### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_fetch_master.yml
+++ b/.github/workflows/docker_fetch_master.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Publish to Dockerhub 
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: wiennat/rjio-fetch
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker_master.yml
+++ b/.github/workflows/docker_master.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build Docker image
         run: docker build . --file Dockerfile --tag rjio
       - name: Publish to Dockerhub 
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: wiennat/rjio
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker_staging.yml
+++ b/.github/workflows/docker_staging.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Build Docker image
         run: docker build . --file Dockerfile --tag rjio
       - name: Publish to Dockerhub 
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: wiennat/rjio
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build Docker image
         run: docker build . --file Dockerfile --tag rjio
       - name: Publish to Dockerhub 
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: wiennat/rjio
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore